### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import fetchrMiddleware from 'redux-effects-fetchr';
 import rootReducer from './reducers';
 
 const fetchr = new Fetchr({
-  xhrPaht: '/api'
+  xhrPath: '/api'
 });
 
 const store = createStore(


### PR DESCRIPTION
Just a tiny typo change: `xhrPaht` -> `xhrPath`
